### PR TITLE
Add note about Ubuntu 22.04 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ libnotify (low controller battery notification)
 Ubuntu 20.04's SDL version is too out of date for this project, for distros like linux mint 20, and zorin os 16,  
 you will have to manually compile SDL2 by yourself and point the pkg config path to the correct place  
 
+For Ubuntu 22.04 LTS:
+```
+sudo apt-get install cmake libsdl2-dev libnotify-dev
+mkdir build
+cd build
+cmake ..
+make
+```
+
 optional:  
 libSDL2 >= 2.0.22 (for wayland)  
 libdecor (for wayland)  


### PR DESCRIPTION
Update Readme to reflect the fact that `libsdl2` is now up to date for Ubuntu 22.04 LTS. Add compilation instructions.

(May need to make more modifications in order to make the installation instructions more readable)