### PR TITLE
Fix build on clang 16

### DIFF
--- a/imgui/imfilebrowser.h
+++ b/imgui/imfilebrowser.h
@@ -390,7 +390,7 @@ inline void ImGui::FileBrowser::Display()
 #endif
 
     int secIdx = 0, newPwdLastSecIdx = -1;
-    for(auto &sec : pwd_)
+    for(const auto &sec : pwd_)
     {
 #ifdef _WIN32
         if(secIdx == 1)
@@ -418,7 +418,7 @@ inline void ImGui::FileBrowser::Display()
     {
         int i = 0;
         std::filesystem::path newPwd;
-        for(auto &sec : pwd_)
+        for(const auto &sec : pwd_)
         {
             if(i++ > newPwdLastSecIdx)
             {


### PR DESCRIPTION
Fix error when using clang 16:

```
imgui/imfilebrowser.h:393:15: error: non-const lvalue reference to type 'reference' (aka 'std::filesystem::path') cannot bind to a temporary of type 'reference' (aka 'std::filesystem::path')
    for(auto &sec : pwd_)
              ^   ~
imgui/imfilebrowser.h:421:19: error: non-const lvalue reference to type 'reference' (aka 'std::filesystem::path') cannot bind to a temporary of type 'reference' (aka 'std::filesystem::path')
        for(auto &sec : pwd_)
                  ^   ~
```